### PR TITLE
Update tutorial-14.md

### DIFF
--- a/doc/tutorial-14.md
+++ b/doc/tutorial-14.md
@@ -742,7 +742,7 @@ Open and modify the above file as follows:
   [:#tax] (set-attr :value tax)
   [:#discount] (set-attr :value discount)
   [:#total] (set-attr :value
-                      (format "%.2f" (calculate quantity price tax discount))))
+                      (format "%.2f" (double (calculate quantity price tax discount)))))
 ```
 
 > NOTE 6: We added the `format` call to format the `Total` value with


### PR DESCRIPTION
I found (format "%.2f" (calculate ...)) was choking on BigInt and Ratio types.  Casting to a double or float fixes the problem.

(Not sure if there's a more elegant solution.  Perhaps it's better to do the casting inside the remote/calculate definition so that it's self contained?)
