### PR TITLE
require enfocus.enlive.syntax-test at REPL

### DIFF
--- a/doc/tutorial-22.md
+++ b/doc/tutorial-22.md
@@ -1034,6 +1034,8 @@ Let's now run the unit tests from the REPL to verify that all the
 ```clj
 user=> (require '[clojure.test :as ct])
 nil
+user=> (require '[enfocus.enlive.syntax-test])
+nil
 user=> (ct/run-tests 'enfocus.enlive.syntax-test)
 
 Testing enfocus.enlive.syntax-test


### PR DESCRIPTION
I don't see this being required above, before we attempt to run (ct/run-tests 'enfocus.enlive.syntax-test). Don't we need this here, or am I confused somehow? Thanks, Matt
