### PR TITLE
Fixed error in tutorial 6 html .js references

### DIFF
--- a/doc/tutorial-06.md
+++ b/doc/tutorial-06.md
@@ -194,14 +194,14 @@ And here is the interested fragment of `shopping.cljs`
 Here is the related fragment of `login.html`
 
 ```html
-    <script src="js/modern.js"></script>
+    <script src="js/login.js"></script>
     <script>modern_cljs.login.init();</script>
 ```
 
 And here is the related fragment of `shopping.html`
 
 ```html
-  <script src="js/modern.js"></script>
+  <script src="js/shopping.js"></script>
   <script>modern_cljs.shopping.init();</script>
 ```
 


### PR DESCRIPTION
Hi, first, thanks for putting this together! I've found it really helpful so far.

I found a little error in tutorial 6. The HTML script snippets for login.html and shopping.html still request modern.js, even though earlier in the tutorial you mention the need to change the modern.js references to the appropriate log/shopping.js file. (The code might still work if there was a lingering modern.js file from earlier, but it definitely breaks if I start the tutorial fresh.)

Anyway, let me know if you want me to do something else, or in addition to, a simple pull request on master.

Thanks again!
Matthew