### PR TITLE
Fix page referring to wrong folder for compiled js

### DIFF
--- a/doc/tutorial-01.md
+++ b/doc/tutorial-01.md
@@ -171,7 +171,7 @@ of `:output-to` keyword of `project.clj`. Save the file as `simple.html` in
 </head>
 <body>
     <!-- pointing to cljsbuild generated js file -->
-    <script src="js/modern.js"></script>
+    <script src="public/js/modern.js"></script>
 </body>
 </html>
 ```


### PR DESCRIPTION
This works for me, but I might have something misconfigured.
Please let me know if this isn't correct.
