### PR TITLE
Address boot-cljs initial run

### DIFF
--- a/doc/second-edition/tutorial-01.md
+++ b/doc/second-edition/tutorial-01.md
@@ -202,6 +202,8 @@ Compiling ClojureScript...
 • main.js
 ```
 
+> Note: You may need to run `boot cljs` twice the first time to get the compilation to complete. You'll know compilation is completed when you see `Compiling Clojurescript` in the output.
+
 You now know why we called the JS file included in the
 `<script>` tag of the `index.html` page `main.js`: just to adhere to an easy
 default.


### PR DESCRIPTION
When running boot-cljs the first time, you might only get an output like this:

```bash
Downloading https://github.com/boot-clj/boot/releases/download/2.4.2/boot.jar...done.
Running for the first time: updating to latest version.
Retrieving boot-2.5.1.jar from https://clojars.org/repo/
#https://github.com/boot-clj/boot
#Fri Dec 18 12:31:33 MST 2015
BOOT_CLOJURE_NAME=org.clojure/clojure
BOOT_VERSION=2.5.1
BOOT_CLOJURE_VERSION=1.7.0
```

If this happens, your app has not compiled and you need to run boot-cljs a second time.