### PR TITLE
Minor corrections: typos, english, and one missing link

### DIFF
--- a/doc/second-edition/tutorial-04.md
+++ b/doc/second-edition/tutorial-04.md
@@ -280,7 +280,7 @@ function validateForm() {
 
 Here, the `validateForm()` function gets the `email` and the
 `password` ids from the form input and verifies that both have value
-(i.e. `lenght > 0`).
+(i.e. `length > 0`).
 
 The `validateForm()` function returns `true` if the validation passes,
 `false` otherwise.

--- a/doc/second-edition/tutorial-05.md
+++ b/doc/second-edition/tutorial-05.md
@@ -521,11 +521,11 @@ Open the `html/js/main.cljs.edn` file and do the above addition.
 > task. Do you remember when at the beginning of this series I wrote
 > about the idiosyncrasies of the building tools when you walk a
 > little bit out of its defaults? This is one them. Here you have to
-> choose between two alternatives: or you adhere to the very diffused
+> choose between two alternatives: either you adhere to the very widespread
 > convention of keeping the `js` resources confined in a `js`
-> subdirectory of the directory where your html pages live, either, to
-> not incur into the above incidental complexity, you stay with the
-> defaults of `boot-cljs` task and completely give up with an almost
+> subdirectory of the directory where your html pages live; or, to
+> not incur the above incidental complexity, you stay with the
+> defaults of `boot-cljs` task and abandon an almost
 > universal convention of the web.
 
 ### bREPLing with the calculator

--- a/doc/second-edition/tutorial-10.md
+++ b/doc/second-edition/tutorial-10.md
@@ -129,7 +129,7 @@ reviewing the html code of `index.html` (i.e., the Login Form).
 > tutorial we're going to replace it with a corresponding service
 > implemented in CLJ.
 
-As you remember, when we reviewed the `Shopping Calculator` code to
+As you remember, when we revised the `Shopping Calculator` code to
 make it more Clojure-ish, we started by changing the `type` attribute
 of the Shopping Form's button from `type="submit"` to
 `type="button"`. But having decided to adhere to a progressive

--- a/doc/second-edition/tutorial-11.md
+++ b/doc/second-edition/tutorial-11.md
@@ -195,8 +195,8 @@ progressive enhancement strategy.
 As you already know, this series of tutorials is about CLJS, not
 CLJ. On the net there are already some very good tutorials on CLJ web
 application development using [ring][7] and [compojure][5]. Despite
-this, we should at least provide a starting point and a track to be
-followed.
+this, we should at least provide a starting point and a direction to
+follow.
 
 ## index.html
 

--- a/doc/second-edition/tutorial-12.md
+++ b/doc/second-edition/tutorial-12.md
@@ -256,7 +256,7 @@ portable) CLJ/CLJS lib:
 
 Starting with the `1.7.0` release, Clojure offers a new way to solve
 the above Feature Expression Problem. I'm not going to explain it
-right now. I'm anticipating you about it only because I rewrote the
+right now. I'm alerting you about it now only because I rewrote the
 [`valip`](https://github.com/magomimmo/valip/tree/0.4.0-SNAPSHOT) lib
 by using that new feature in such a way that we can easily use it
 inside our series of tutorials without having to do with the above
@@ -536,7 +536,7 @@ directory in the `build.boot` building file.
 
 ## src/cljc
 
-Even if `boot` is so nice that allows you to modify the `environment`
+Even though `boot` is so nice that it allows you to modify the `environment`
 from the REPL with the `set-env!` function, the updating of the
 `build.boot` file is one of the rare cases where I prefer to stop the
 IFDE, make the changes and then restart it.
@@ -622,7 +622,7 @@ cljs.user=>
 ```
 
 Do you want to see if the `valip` namespaces are available from the
-CLJS as well? Require them an interact with some of the predicates.
+CLJS as well? test them by interacting with some of the predicates.
 
 ```clj
 cljs.user> (require '[valip.core :refer [validate]]
@@ -730,14 +730,14 @@ nil
 ```
 
 WOW, I don't know about you, but anytime I see this magic at work, I
-would kiss any CLJ/CLJS contributor one by one. No way that anybody
-could convince me to that there is something better than CLJ/CLJS on
+could kiss the CLJ/CLJS contributors one by one. No way that anybody
+could convince me that there is something better than CLJ/CLJS on
 the web planet.
 
 ## Back on Earth
 
 OK, we had enough magic for now. Let's came back on Earth to update
-the CLJS `modern-cljs.login` namespace by using those magics.
+the CLJS `modern-cljs.login` namespace by using this magic.
 
 Open the `login.cljs` source file living in the `src/cljs/modern_cljs`
 directory to start updating it while the IFDE is running:

--- a/doc/second-edition/tutorial-13.md
+++ b/doc/second-edition/tutorial-13.md
@@ -101,7 +101,7 @@ Elapsed time: 19.288 sec
 and visit the [shopping URI][2] for reviewing the Shopping Calculator
 program.
 
-Click the `Calculate` button. The `Total` field is valued with the
+Click the `Calculate` button. The `Total` field is populated with the
 result of the calculation executed via Ajax on the server-side.
 
 Note that the `localhost:3000/shopping.html` URI shown in the address
@@ -173,7 +173,7 @@ does not respond to any event.
 Now modify the `shoppingForm` by adding the `action="/shopping"` and
 the `method="POST"` attribute/value pairs. Next, change the Calculate
 input from `type="button"` to `type="submit"` attribute/value
-pair. Following is the interested snippet of the modified HTML code.
+pair. Following is the interesting snippet of the modified HTML code.
 
 ```html
   ...
@@ -697,7 +697,7 @@ Open and modify the above file as follows:
 ```
 
 > NOTE 4: We added the `format` call to format the `Total` value with
-> two digits after the decimal point. Note that we [casted][32] the
+> two digits after the decimal point. Note that we [cast][32] the
 > `calculate` result to `double`.
 
 Assuming that you have your IFDE running, as soon as you save the file
@@ -721,7 +721,7 @@ modern-cljs.templates.shopping -> modern-cljs.remotes
 -> modern-cljs.core -> modern-cljs.templates.shopping
 ```
 
-Our scenario is simple enough. Remove the `modern-cljs.core` reference
+Our solution is simple enough. Remove the `modern-cljs.core` reference
 from the `modern-cljs.remotes` namespace declaration. There, we only
 referenced the `handler` symbol from the `modern-cljs.core` namespace
 in the `app` definition. By moving the `app` definition to the

--- a/doc/second-edition/tutorial-14.md
+++ b/doc/second-edition/tutorial-14.md
@@ -250,7 +250,7 @@ that are applicable to a portable CLJ/CLJS namespace like
 That said, most of the `cljs.test` functionalities are provided as
 macros, which means that you need the special CLJS `:require-macros`
 option in the requirement declaration of a testing namespace, while
-you do no need it in the corresponding CLJ namespace declaration.
+you do not need it in the corresponding CLJ namespace declaration.
 
 We already met a case like that. Indeed, while writing the portable
 `modern-cljs.login.validators` namespace, we needed to differentiate
@@ -442,12 +442,12 @@ reporting of failure reports.
 
 To run the newly defined unit test for the
 `modern-cljs.shopping.validators` namespace we have more options. The
-one we're going to use right now does not require to kill the running
+one we're going to use right now does not require killing the running
 `boot` process even if we're going to alter the `boot` environment
 established by the `build.boot` file when we started IFDE with the
 `boot dev` command.
 
-This is the first time in the series that we do no stop `boot` to
+This is the first time in the series that we do not stop `boot` to
 alter its runtime environment. Sometimes it could be useful,
 especially when you're experimenting something new and this is our
 case.
@@ -551,7 +551,7 @@ Ran 1 tests containing 3 assertions.
 
 Oops, nothing new happens. The unit test succeeded again. The problem
 is that even if the `validate-shopping-form-test` function got
-redefined and recompiled, `cojure.test` still knows about the old
+redefined and recompiled, `clojure.test` still knows about the old
 definition. To obtain the expected effect we have to explicitly reload
 the `modern-cljs.shopping.validators-test` namespace and re-run
 `run-tests`.
@@ -573,11 +573,11 @@ Ran 1 tests containing 3 assertions.
 {:test 1, :pass 2, :fail 1, :error 0, :type :summary}
 ```
 
-Now we talk. Even if the failure report does require a bit of
+Now we are talking. Even if the failure report does require a bit of
 interpretation at first, after a while you can grasp it quicker.
 
 Now revert the above test to the good form, reload its namespace and
-rerun `run-tests` to got back to the right test result.
+rerun `run-tests` to get back to the right test result.
 
 ```clj
 boot.user> (require '[modern-cljs.shopping.validators-test] :reload)
@@ -595,7 +595,7 @@ Ran 1 tests containing 3 assertions.
 
 The coded test includes only few assertions regarding the working path
 of the `validate-shopping-form` calls. Generally speaking you should
-cover also the *alternative/exception paths*. Let's add few of them in
+also cover the *alternative/exception paths*. Let's add few of them in
 our first test.
 
 ```clj

--- a/doc/second-edition/tutorial-16.md
+++ b/doc/second-edition/tutorial-16.md
@@ -34,7 +34,7 @@ We'd like to please them a little bit better than that.
 ## Task Options DSL
 
 As you can read from the Wiki page cited above, `boot` is a servant of
-more owners and it has to please them all:
+many owners and it has to please them all:
 
 > `boot` tasks are intended to be used from the command line, from a
 > REPL, in the project's build.boot file, or from regular Clojure
@@ -219,7 +219,7 @@ step, stop the `boot` process.
 
 ### Update build.boot
 
-We know enough to start updating the `testing` task. Considering that
+We now know enough to start updating the `testing` task. Considering that
 what `testing` really does it is to add paths to the `:source-paths`
 environment variable, we'll change its name to `add-source-paths` as
 well:

--- a/doc/second-edition/tutorial-17.md
+++ b/doc/second-edition/tutorial-17.md
@@ -335,7 +335,7 @@ boot.user> (e/sniptest (html [:fieldset [:div [:label {:for "price"} "Price per 
 ```
 
 The `[:label]` selector selected both `label` elements inside the
-`fieldset` element. The corresponding transformer consequentely
+`fieldset` element. The corresponding transformer consequently
 changed the content of both of them. Luckly, Enlive offers a rich set
 of predicates which can be applied to be more specific within the
 selectors. One of them is `attr=`, which tests if an attribute has a

--- a/doc/second-edition/tutorial-18.md
+++ b/doc/second-edition/tutorial-18.md
@@ -279,7 +279,7 @@ symbol to the `:refer` section of the
                :cljs [cljs.test :refer-macros [deftest are testing]])))
 ```
 
-As soon as you save the file, you'll receive again an expected error:
+As soon as you save the file, you'll again receive an expected error:
 
 ```bash
 ...

--- a/doc/second-edition/tutorial-19.md
+++ b/doc/second-edition/tutorial-19.md
@@ -220,7 +220,7 @@ Virtual Machine) either via the `:crossover` feature of the
 [lein-cljsbuild](https://github.com/emezeske/lein-cljsbuild) plugin or
 via the [`lein-cljx`](https://github.com/lynaghk/cljx) plugin.
 
-Let's comment the current directory layout of the `valip` library:
+Let's explore the current directory layout of the `valip` library:
 
 * all the functions specific to the JVM are confined in the
   `predicates.clj` source file hosted in the `src/valip/java`
@@ -234,7 +234,7 @@ Let's comment the current directory layout of the `valip` library:
 * all the macros are confined in the `def.clj` source file hosted in
   the `src/valip/predicates` directory.
 
-So far, so good. But what does it stand for that `reader.clj` source
+So far, so good. But what does it mean that `reader.clj` source
 file hosted in the `src/cljs` directory?
 
 ## A smart trick by a smart guy
@@ -507,7 +507,7 @@ talked about above:
 functions when dealing with untrusted sources in CLJ.
 
 That said, both `cljs.reader/read` and `cljs.reader/read-string` are
-not affected from the same security issues, because they adopted the
+not affected by the same security issues, because they adopted the
 same approach used to implement `clojure.edn/read` and
 `clojure.edn/read-string` which can read data structure, but are not
 able to evaluate them.
@@ -516,7 +516,7 @@ All that to say that in the `valip.predicates` namespace declaration
 we have to differentiate the reader namespace requirement between CLJ
 and CLJS.
 
-Following is the `valip.predicates` namespace declaration absorbing
+Following is the `valip.predicates` namespace declaration incorporating
 the above solution for the cited security issue and any other specific
 namespace declaration specific for the two considered platforms (i.e.,
 JVM an JSVM):
@@ -653,13 +653,13 @@ tree
 6 directories, 7 files
 ```
 
-As you see the only survived pure CLJ file is `def.clj` which is the
+As you see the only surviving pure CLJ file is `def.clj`, which is the
 one containing the macros definitions.
 
 Those steps represent the easiest part of making the `valip`
 validation library compliant with the Reader Conditionals
 extension. If we want to stay with the `leiningen` build tool, we
-should now afford the difficult ones:
+should now attempt the difficult ones:
 
 * the addition of the
   [`lein-cljsbuild`](https://github.com/emezeske/lein-cljsbuild)
@@ -1349,7 +1349,7 @@ You can now stop the `boot` process to proceed with the next step.
 
 The fact the migrated `valip` library has been successful tested on
 CLJ does not mean that it will work on CLJS as well. We should now
-afford another boring part: tooling.
+attempt another boring part: tooling.
 
 As you saw above, it was very easy to run and test the CLJ version of
 `valip` library by using a couple of default
@@ -1442,7 +1442,7 @@ WARNING: No such namespace: goog.Uri, could not locate goog/Uri.cljs, goog/Uri.c
 WARNING: Use of undeclared Var goog.Uri/parse at line 127 src/valip/predicates.cljc
 ```
 
-Ops. We immediately got a couple of warning. The first says the CLJS
+Oops. We immediately got a couple of warning. The first says the CLJS
 compiler was not able to find the
 [`goog.Uri`](https://google.github.io/closure-library/api/class_goog_Uri.html)
 namespace. The second warning says that its `parse` symbol it is
@@ -1452,7 +1452,7 @@ Uhm, pretty weird warnings.
 
 ## Getting rid of warnings
 
-To me actual warnings are potential errors and I don't like at all to
+To me, warnings are potential errors and I don't at all like to
 let them survive to eventually wake me up at night or while I'm on
 vacation. This to say that we're now going to get rid of them.
 
@@ -1573,9 +1573,9 @@ declaration and then uses the class as a namespace:
                   (re-find #"//" (str s))))))
 ```
 
-We have to make a choice and be coherent with it to not make a reader
-of our code disoriented, but be prepared to read all the other three
-form in the wild.
+We have to make a choice and we need to be coherent with it, so we
+don't disorient the readers of our code. But be prepared to read
+all the other three form in the wild.
 
 > NOTE 8: [Shane Kilkelly](https://github.com/ShaneKilkelly) suggested
 > me to use the third form, `(goog.Uri.parse (str s))`, because

--- a/doc/second-edition/tutorial-20.md
+++ b/doc/second-edition/tutorial-20.md
@@ -46,8 +46,8 @@ we switched to `leiningen` and locally installed the updated version
 of `valip` by using the `lein install` task. This was because the
 `project.clj` build file used by `leiningen` already had the
 [minimal information](https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#Minimal_POM)
-needed to create and package the `valip` library, while we did not
-informed the corresponding `build.boot` build file used by `boot` with
+needed to create and package the `valip` library, while we had not
+updated the corresponding `build.boot` build file used by `boot` with
 the same information, namely:
 
 * the `groupId:` it has to follow the java package name rules; e.g.,
@@ -373,7 +373,7 @@ install` command we used in the [previous tutorial][1]: enter
 build file.  If you're only using built-in tasks, you can place it
 just after the `set-env!` form. If you are using other tasks, you'll
 place `task-options!` after the requirement form. Following it is the
-complete revisited version of the `build.boot` build file for the
+complete updated version of the `build.boot` build file for the
 `valip` project:
 
 ```clj
@@ -620,7 +620,7 @@ jar -tvf ~/.m2/repository/org/clojars/magomimmo/valip/0.4.0-SNAPSHOT/valip-0.4.0
     25 Sun Jan 10 15:25:14 CET 2016 META-INF/MANIFEST.MF
 ```
 
-That's much better. Run again the `modern-cljs` project to see the
+That's much better. Run the `modern-cljs` again project to see the
 result:
 
 ```bash
@@ -649,8 +649,8 @@ Writing target dir(s)...
 Elapsed time: 28.470 sec
 ```
 
-Now we talk. Just to be sure that everything is still working as for
-the end of the
+Now we are talking. Just to be sure that everything is still working
+as at the end of the
 [Tutorial 18](https://github.com/magomimmo/modern-cljs/blob/master/doc/second-edition/tutorial-18.md#on-improving-ux-user-experience),
 visit the [Shopping Calculator](http://localhost:3000/shopping.html)
 URL to play with the Shopping Calculator.

--- a/doc/second-edition/tutorial-20.md
+++ b/doc/second-edition/tutorial-20.md
@@ -1041,7 +1041,7 @@ Deploying valip-0.4.0-SNAPSHOT.jar...
 
 That's all folks. Stay tune for the next tutorial.
  
-## Next Step - TBD
+## Next Step - [Tutorial 21 The Real World][3]
 
 # License
 
@@ -1050,3 +1050,4 @@ License, the same as Clojure.
 
 [1]: https://github.com/magomimmo/modern-cljs/blob/master/doc/second-edition/tutorial-19.md
 [2]: https://github.com/magomimmo/modern-cljs/blob/master/doc/second-edition/tutorial-18.md
+[3]: https://github.com/magomimmo/modern-cljs/blob/master/doc/second-edition/tutorial-21.md

--- a/doc/second-edition/tutorial-21.md
+++ b/doc/second-edition/tutorial-21.md
@@ -64,7 +64,7 @@ populated of independent entities, the single sequence execution
 computational model is not adequate. Let's say that you're modeling a
 car factory.
 
-> NOTE 1: I'm steeling the car factory sample from
+> NOTE 1: I'm stealing the car factory sample from
 > [Tom Baldrige](https://tbaldridge.pivotshare.com) and
 > [Eric Normand](http://www.purelyfunctional.tv/core-async).
 
@@ -132,7 +132,7 @@ the process and  this is exactly what CSP is  all about: processes and
 communication channels.
 
 One of the nice thing about CSP channels, is that they support many
-writers ans many readers as well and this allows easily improve
+writers as well as many readers, and this allows easily improved
 performance. For example, say that the `assemble-car`
 
 To create a channel you use the `chan` function as follows:
@@ -144,13 +144,11 @@ To create a channel you use the `chan` function as follows:
 By default the created channel is unbuffered (0 size). To `put` a value into a channel, you use the ``put!` function as follows:
 
 
-. This is
-exactly how CSP works. There are Processes and there are Channels. 
-
+This is exactly how CSP works. There are Processes and there are Channels.
 
 
 The problem with the synchronous
-model of computation is of efficiency nature. Say that the `g`
+model of computation is one of efficiency. Say that the `g`
 function internally does a long I/O operation, the next `h` function
 has to wait until `g` returns. In the meantime `g` does its I/O jobs,
 the system is blocked and is not using its computation resources at
@@ -170,7 +168,7 @@ output or messages from other programs/thread.
 ## Function chains make poor machine
 
 As usual, by solving a current problem, we're frequently setting the
-bases for a new problem to manifest itself later. In an event-driven
+basis for a new problem to manifest itself later. In an event-driven
 approach, there is usually a main loop listening for events of various
 types. When an event of some type appears, the loop triggers a
 function, conveniently known as callback, that has been previously
@@ -185,7 +183,7 @@ places. When the application becomes more complex, as it always
 happens with Single Page Applications, it becomes very difficult to
 reason about the application logic and its state. A callback triggered
 by the occurrence of an event will trigger a second callback which, in
-turn, will triggers a third callback an so on.
+turn, will triggers a third callback and so on.
 
 This situation is very well known and it also deserved a name:
 callback hell. Callback hell affects JS on the client-side (browser)
@@ -258,10 +256,10 @@ nil
 ```
 
 As you probably heard from Rich Hickey talk on `core.async`, *function
-chains make poor machines*. What does it means? We should first find
+chains make poor machines*. What does it mean? We should first find
 out what are function chains and what are machine to be able to
-eventually understand what does it means the function chains make poor
-machine and why this statement should be true.
+eventually understand what does it mean that function chains make poor
+machines and why this statement should be true.
 
 A function chain is very easy to be understand. It's just a function
 calling another function, calling another function, and so on, like so:


### PR DESCRIPTION
Here are some straightforward English fixes. Also, I added a missing link to Tutorial 21, though perhaps you omitted it deliberately since 21 is incomplete.  (My opinion is that it is still worthwhile to include the link, since the existing part of 21 already has much value, as it informs beginners of the existence of core.async).