### PR TITLE
Tutoral 5 typo fix: modern.js -> main.js in index.html

### DIFF
--- a/doc/second-edition/tutorial-05.md
+++ b/doc/second-edition/tutorial-05.md
@@ -157,7 +157,7 @@ Before we start bREPLing, let's review the content of the
 
         </fieldset>
     </form>
-    <script src="js/modern.js"></script>
+    <script src="js/main.js"></script>
 </body>
 </html>
 ```


### PR DESCRIPTION
The previous tutorial had us change this line to `js/main.js` in order to use the JS file generated by the CLJS compiler.