### PR TITLE
Add Emacs and CIDER references

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ IDE/plugins for Clojure/CLJS to say that one is better than another, and
 you don't want to combine learning a new programming language with trying
 to learn a new programming environment.
 
+> NOTE: If you are interested in learning more about Emacs here are some 
+[resources to help get you started]
+(https://github.com/magomimmo/modern-cljs/blob/master/doc/supplemental-material/emacs-cider-references.md).
+
 You will need to have [git][16] and [Java][34] installed and you'll
 need some familiarity with the [basics of git][17].
 

--- a/doc/second-edition/tutorial-02.md
+++ b/doc/second-edition/tutorial-02.md
@@ -434,6 +434,9 @@ different). If your editor supports `nrepl` you are going to use that
 information to connect to the now running `nrepl server` with an
 `nrepl client`.
 
+> NOTE: Emacs and CIDER support this.  You can learn more about them with these [resources]
+(https://github.com/magomimmo/modern-cljs/blob/master/doc/supplemental-material/emacs-cider-references.md).
+
 At the moment we're happy enough to be able to run `cljs-repl` from a
 second terminal by first launching the predefined `repl` task included
 with `boot` and passing it the `-c` (i.e. client) option:

--- a/doc/second-edition/tutorial-04.md
+++ b/doc/second-edition/tutorial-04.md
@@ -326,6 +326,10 @@ cljs.user=>
 > personally use `emacs` editor and [cider][16] only because I'm aged
 > and `emacs` is the editor I know how to configure and use the best.
 
+> If you are interested in learning more about Emacs or CIDER [here are
+some references]
+(https://github.com/magomimmo/modern-cljs/blob/master/doc/supplemental-material/emacs-cider-references.md).
+
 
 We can now evaluate CLJS expressions at the bREPL, but we first need a
 way to access the browser DOM.

--- a/doc/second-edition/tutorial-15.md
+++ b/doc/second-edition/tutorial-15.md
@@ -866,6 +866,10 @@ Still working.
 > you'll end up with a total of three JVM instance, without counting
 > the one eventually created by your Editor/IDE.
 
+> If you are interested in learning about Emacs and CIDER
+[here are some resources]
+(https://github.com/magomimmo/modern-cljs/blob/master/doc/supplemental-material/emacs-cider-references.md).
+
 Now start the CLJS bREPL
 
 ```clj

--- a/doc/supplemental-material/emacs-cider-references.md
+++ b/doc/supplemental-material/emacs-cider-references.md
@@ -1,0 +1,21 @@
+# GNU Emacs and CIDER resources
+
+## GNU Emacs
+
+What is [GNU Emacs](https://en.wikipedia.org/wiki/GNU_Emacs)?
+
+This is the [GNU Emacs website](https://www.gnu.org/software/emacs/).
+
+Here are instructions on how to install [GNU Emacs](https://www.gnu.org/software/emacs/download.html).
+
+Here is [documentation for GNU Emacs](https://www.gnu.org/software/emacs/documentation.html).
+
+The book [Clojure for the brave and true](http://www.braveclojure.com/) that is available online has a chapter that covers [getting started with Clojure in GNU Emacs](http://www.braveclojure.com/basic-emacs/).
+
+## CIDER
+
+Here is an [overview of CIDER](https://cider.readthedocs.org/en/latest/).
+
+Here is how to [install Cider](https://cider.readthedocs.org/en/latest/installation/).
+
+Here is [CIDER's up and running guide](https://cider.readthedocs.org/en/latest/up_and_running/).


### PR DESCRIPTION
This adds a stand alone page of links for Emacs and CIDER resources.
It also adds links to this page of links where Emacs and CIER are mentioned in the tutorial series.