### PR TITLE
replaced '.getElementById' by 'by-id' from domina to stay consistent

### DIFF
--- a/src/cljs/modern_cljs/shopping.cljs
+++ b/src/cljs/modern_cljs/shopping.cljs
@@ -15,7 +15,7 @@
 (defn init []
   (if (and js/document
            (.-getElementById js/document))
-    (let [the-form (.getElementById js/document "shoppingForm")]
+    (let [the-form (by-id "shoppingForm")]
       (set! (.-onsubmit the-form) calculate))))
 
 (set! (.-onload js/window) init)


### PR DESCRIPTION
note: the init function of loginForm.cljs was left unchanged since it's specified in the tutorial that it is the case.It is also not shown to the reader after using domina selector. However the init function of shopping.cljs is shown in the tutorial after using domina selector- It is not consistent with the validate-form function update.