### PR TITLE
Update boot-reload dependency in Second Edition

### DIFF
--- a/doc/second-edition/tutorial-02.md
+++ b/doc/second-edition/tutorial-02.md
@@ -236,7 +236,7 @@ visible to `boot` by requiring its primary command:
  
  :dependencies '[[adzerk/boot-cljs "1.7.170-3"]
                  [pandeiro/boot-http "0.7.0"]
-                 [adzerk/boot-reload "0.4.2"]]) ;; add boot-reload
+                 [adzerk/boot-reload "0.4.9"]]) ;; add boot-reload
 
 (require '[adzerk.boot-cljs :refer [cljs]]
          '[pandeiro.boot-http :refer [serve]]
@@ -303,7 +303,7 @@ command at the terminal.
  
  :dependencies '[[adzerk/boot-cljs "1.7.170-3"]
                  [pandeiro/boot-http "0.7.0"]
-                 [adzerk/boot-reload "0.4.1"]
+                 [adzerk/boot-reload "0.4.9"]
                  [adzerk/boot-cljs-repl "0.3.0"]]) ;; add bREPL
 
 (require '[adzerk.boot-cljs :refer [cljs]]
@@ -346,7 +346,7 @@ the `build.boot` build file.
                  [org.clojure/clojurescript "1.7.170"] ;; add CLJS
                  [adzerk/boot-cljs "1.7.170-3"]
                  [pandeiro/boot-http "0.7.0"]
-                 [adzerk/boot-reload "0.4.2"]
+                 [adzerk/boot-reload "0.4.9"]
                  [adzerk/boot-cljs-repl "0.3.0"]
                  ])
 
@@ -388,7 +388,7 @@ dependencies and you have to explicitly add them in the
                  [org.clojure/clojurescript "1.7.170"]
                  [adzerk/boot-cljs "1.7.170-3"]
                  [pandeiro/boot-http "0.7.0"]
-                 [adzerk/boot-reload "0.4.2"]
+                 [adzerk/boot-reload "0.4.9"]
                  [adzerk/boot-cljs-repl "0.3.0"]
                  [com.cemerick/piggieback "0.2.1"]     ;; needed by bREPL 
                  [weasel "0.7.0"]                      ;; needed by bREPL


### PR DESCRIPTION
While following along with the boot-reload setup in [the second section](https://github.com/magomimmo/modern-cljs/blob/master/doc/second-edition/tutorial-02.md#resources-reloading), I had to do some debugging to get the boot-reload working properly. After digging around, I found [this issue](https://github.com/juxt/edge/issues/7). I upgraded the dependency accordingly, and the problem was fixed.

If there are better/more places you'd like to see this fix applied to, I'd be more than happy to help. Thanks for the guide!