### PR TITLE
Fix syntax highlighting in tutorial 16

### DIFF
--- a/doc/second-edition/tutorial-16.md
+++ b/doc/second-edition/tutorial-16.md
@@ -273,7 +273,7 @@ same task option to `tdd` as well, so that we can pass a
 test directory on the command line and have it added
 to the `:source-paths` variable.
 
-```bash
+```clj
 (deftask tdd
   "Launch a customizable TDD Environment"
   [t dirs PATH #{str} "test paths"]


### PR DESCRIPTION
The code block that adds the `dirs` option to the `tdd` task was using `bash` instead of `clj` syntax highlighting.