### PR TITLE
Fix typo in id attribute

### DIFF
--- a/doc/second-edition/tutorial-21.md
+++ b/doc/second-edition/tutorial-21.md
@@ -962,7 +962,7 @@ Here is the new React code from the official tutorial:
 ```js
 var data = [
   {id: 1, author: "Pete Hunt", text: "This is one comment"},
-  {Id: 2, author: "Jordan Walke", text: "This is *another* comment"}
+  {id: 2, author: "Jordan Walke", text: "This is *another* comment"}
 ];
 ```
 


### PR DESCRIPTION
Change `Id` to `id` in the data source example in JS.
As is, it is causing the second list item to have a missing key on being rendered