### PR TITLE
Fixed markdown layout bug

### DIFF
--- a/doc/second-edition/tutorial-02.md
+++ b/doc/second-edition/tutorial-02.md
@@ -459,8 +459,8 @@ different). If your editor supports `nrepl` you are going to use that
 information to connect to the now running `nrepl server` with an
 `nrepl client`.
 
-> NOTE: Emacs and CIDER support this. You can learn more about them with these [resources]
-(https://github.com/magomimmo/modern-cljs/blob/master/doc/supplemental-material/emacs-cider-references.md).
+> NOTE: Emacs and CIDER support this. You can learn more about them with these 
+[resources](https://github.com/magomimmo/modern-cljs/blob/master/doc/supplemental-material/emacs-cider-references.md).
 
 At the moment we're happy enough to be able to run `cljs-repl` from a
 second terminal by first launching the predefined `repl` task included


### PR DESCRIPTION
The text was being wrapped such that the markdown link was being broken. This has been corrected.