### PR TITLE
Normalize indentation to spaces

### DIFF
--- a/doc/second-edition/tutorial-02.md
+++ b/doc/second-edition/tutorial-02.md
@@ -244,7 +244,7 @@ visible to `boot` by requiring its primary command:
 
  :dependencies '[[adzerk/boot-cljs "1.7.228-2"]
                  [pandeiro/boot-http "0.7.6"]
-		             [org.clojure/tools.nrepl "0.2.12"]
+                 [org.clojure/tools.nrepl "0.2.12"]
                  [adzerk/boot-reload "0.5.1"]]) ;; add boot-reload
 
 (require '[adzerk.boot-cljs :refer [cljs]]
@@ -360,7 +360,7 @@ the `build.boot` build file.
                  [org.clojure/clojurescript "1.9.473"] ;; add CLJS
                  [adzerk/boot-cljs "1.7.228-2"]
                  [pandeiro/boot-http "0.7.6"]
-		             [org.clojure/tools.nrepl "0.2.12"]
+                 [org.clojure/tools.nrepl "0.2.12"]
                  [adzerk/boot-reload "0.5.1"]
                  [adzerk/boot-cljs-repl "0.3.3"]
                  ])


### PR DESCRIPTION
Hello!

Thanks for a (so far) great guide.

I found some mixture of tabs and spaces in your second tutorial, which caused funny indentation with Github's preview.

Source with tabs and spaces:
![image](https://user-images.githubusercontent.com/5285452/34365818-e2e758e2-ea94-11e7-89bc-c2343aa22bd7.png)

Rendered:
![image](https://user-images.githubusercontent.com/5285452/34365841-1717d0c4-ea95-11e7-89e8-bafb15f69daf.png)

Regards,
Teodor