### PR TITLE
Fix a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ License, the same license as Clojure.
 [5]: https://github.com/clojure/clojurescript.git
 [6]: https://github.com/clojure/clojurescript/wiki/Quick-Start#running-clojurescript-on-nodejs
 [7]: http://www.clojurebook.com/
-[8]: http://pragprog.com/book/shcloj2/programming-clojure
+[8]: https://pragprog.com/titles/shcloj3/programming-clojure-third-edition/
 [9]: http://www.joyofclojure.com/
 [10]: http://shop.oreilly.com/product/0636920025139.do
 [11]: http://mitpress.mit.edu/sicp/


### PR DESCRIPTION
The link to the "Programming Clojure" is broken